### PR TITLE
Mark Confluence app read mode compatible

### DIFF
--- a/confluence/scio_search/src/main/resources/atlassian-plugin.xml
+++ b/confluence/scio_search/src/main/resources/atlassian-plugin.xml
@@ -5,6 +5,7 @@
     <vendor name="${project.organization.name}" url="${project.organization.url}"/>
     <param name="atlassian-data-center-status">compatible</param>
     <param name="atlassian-data-center-compatible">true</param>
+    <param name="read-only-access-mode-compatible">true</param>
     <param name="plugin-type">server</param>
     <param name="plugin-icon">images/pluginIcon.png</param>
     <param name="plugin-logo">images/pluginLogo.png</param>


### PR DESCRIPTION
As an approved app, we need to mark it read mode compatible from here https://developer.atlassian.com/server/confluence/how-to-make-your-add-on-compatible-with-read-only-mode/