### PR TITLE
[CONFLUENCE PLUGIN] Support edit urls

### DIFF
--- a/confluence/server/scio_search/pom.xml
+++ b/confluence/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.askscio.atlassian_plugins.confluence</groupId>
   <artifactId>glean_search</artifactId>
-  <version>1.1.3</version>
+  <version>1.2.1</version>
 
   <organization>
     <name>Glean</name>

--- a/confluence/server/scio_search/pom.xml
+++ b/confluence/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.askscio.atlassian_plugins.confluence</groupId>
   <artifactId>glean_search</artifactId>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
 
   <organization>
     <name>Glean</name>

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
@@ -72,7 +72,7 @@ public class ScioSearchServletFilter implements Filter {
     // Saving a page or blogpost fires: PUT http://confluence-server:8090/rest/api/content/65603?status=draft
     if (httpreq.getRequestURI().startsWith("/rest/api/content/") &&
         ("PUT".equals(httpreq.getMethod()) || "POST".equals(httpreq.getMethod()) || "DELETE".equals(httpreq.getMethod()))) {
-      logger.debug("Save url: " + httpreq.getRequestURI());
+      logger.debug("Save url: " + httpreq.getMethod() + ": " + httpreq.getRequestURI());
     } else if (!httpreq.getRequestURI().contains("viewpage")
         && !httpreq.getRequestURI().contains("/display/")) {
       logger.debug(String.format("Uninteresting visit: %s", httpreq.getRequestURI()));

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
@@ -141,11 +141,11 @@ public class ScioSearchServletFilter implements Filter {
       String query = httpreq.getQueryString();
       if (query == null || query.isEmpty()) {
         visitUrl = new URL(
-          String.format("%s%s", baseURL, httpreq.getRequestURI()));
+          String.format("%s%s?glean_http_method=%s", baseURL, httpreq.getRequestURI(), httpreq.getMethod()));
       } else {
         visitUrl =
             new URL(
-                String.format("%s%s?%s", baseURL, httpreq.getRequestURI(), query));
+                String.format("%s%s?%s&glean_http_method=%s", baseURL, httpreq.getRequestURI(), query, httpreq.getMethod()));
       }
     } catch (MalformedURLException e) {
       logger.warn(String.format("Malformed URL: %s", e.getMessage()));

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
@@ -137,9 +137,15 @@ public class ScioSearchServletFilter implements Filter {
 
     final URL visitUrl;
     try {
-      visitUrl =
-          new URL(
-              String.format("%s%s?%s", baseURL, httpreq.getRequestURI(), httpreq.getQueryString()));
+      String query = httpreq.getQueryString();
+      if (query == null || query.isEmpty()) {
+        visitUrl = new URL(
+          String.format("%s%s", baseURL, httpreq.getRequestURI()));
+      } else {
+        visitUrl =
+            new URL(
+                String.format("%s%s?%s", baseURL, httpreq.getRequestURI(), query));
+      }
     } catch (MalformedURLException e) {
       logger.warn(String.format("Malformed URL: %s", e.getMessage()));
       filterChain.doFilter(servletRequest, servletResponse);

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
@@ -69,8 +69,9 @@ public class ScioSearchServletFilter implements Filter {
     }
 
     final HttpServletRequest httpreq = (HttpServletRequest) servletRequest;
-    // Saving a page or blogpost fires: PUT http://bharath-test:8090/rest/api/content/65603?status=draft
-    if ("PUT".equals(httpreq.getMethod()) && httpreq.getRequestURI().startsWith("/rest/api/content/")) {
+    // Saving a page or blogpost fires: PUT http://confluence-server:8090/rest/api/content/65603?status=draft
+    if (httpreq.getRequestURI().startsWith("/rest/api/content/") &&
+        ("PUT".equals(httpreq.getMethod()) || "POST".equals(httpreq.getMethod()) || "DELETE".equals(httpreq.getMethod()))) {
       logger.debug("Save url: " + httpreq.getRequestURI());
     } else if (!httpreq.getRequestURI().contains("viewpage")
         && !httpreq.getRequestURI().contains("/display/")) {

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
@@ -69,7 +69,10 @@ public class ScioSearchServletFilter implements Filter {
     }
 
     final HttpServletRequest httpreq = (HttpServletRequest) servletRequest;
-    if (!httpreq.getRequestURI().contains("viewpage")
+    // Saving a page or blogpost fires: PUT http://bharath-test:8090/rest/api/content/65603?status=draft
+    if ("PUT".equals(httpreq.getMethod()) && httpreq.getRequestURI().startsWith("/rest/api/content/")) {
+      logger.debug("Save url: " + httpreq.getRequestURI());
+    } else if (!httpreq.getRequestURI().contains("viewpage")
         && !httpreq.getRequestURI().contains("/display/")) {
       logger.debug(String.format("Uninteresting visit: %s", httpreq.getRequestURI()));
       filterChain.doFilter(servletRequest, servletResponse);


### PR DESCRIPTION
- In 7.4.17, when a user saves a page or blogpost, a PUT request is made to /rest/api/content. Send this as an event.
- In 7.4.17, when a user deletes a page, /rest/api/content is not invoked (archiving of page). When the page is actually purged, again /rest/api/content is not being invoked. The current confluence server api suggests that POST is used for creation and DELETE for deletion. So those two are also added.
- Handle null query when sending the url in the event
- Add http method as a query param
