### PR TITLE
[Confluence Plugin] Add request handler for plugin version check 

### DIFF
--- a/confluence/server/scio_search/pom.xml
+++ b/confluence/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.askscio.atlassian_plugins.confluence</groupId>
   <artifactId>glean_search</artifactId>
-  <version>1.2.1</version>
+  <version>1.3.0</version>
 
   <organization>
     <name>Glean</name>

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Constants.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Constants.java
@@ -1,0 +1,5 @@
+package com.askscio.atlassian_plugins.confluence.impl;
+
+public class Constants {
+  public static final String PLUGIN_KEY = "com.askscio.atlassian_plugins.confluence.glean_search";
+}

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchPluginVersionFetch.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchPluginVersionFetch.java
@@ -1,0 +1,29 @@
+package com.askscio.atlassian_plugins.confluence.impl;
+
+import com.atlassian.plugin.PluginAccessor;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Named
+@Path("/version")
+public class ScioSearchPluginVersionFetch {
+
+  @ConfluenceImport private final PluginAccessor pluginAccessor;
+
+  @Inject
+  public ScioSearchPluginVersionFetch(PluginAccessor pluginAccessor) {
+    this.pluginAccessor = pluginAccessor;
+  }
+
+  @GET
+  @Produces({MediaType.APPLICATION_JSON})
+  public ScioSearchPluginVersionResponse getVersion() {
+    String pluginVersion = pluginAccessor.getPlugin(Constants.PLUGIN_KEY).getPluginInformation().getVersion();
+    return new ScioSearchPluginVersionResponse(pluginVersion);
+  }
+}

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchPluginVersionResponse.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchPluginVersionResponse.java
@@ -1,0 +1,13 @@
+package com.askscio.atlassian_plugins.confluence.impl;
+
+import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+public class ScioSearchPluginVersionResponse {
+  private final String version;
+
+  ScioSearchPluginVersionResponse(String version) {
+    this.version = version;
+  }
+}


### PR DESCRIPTION
* Adding a request handler for plugin check can be useful in several ways:
  * Verify if the plugin is installed. Currently we only support endpoints for admin accounts. Exposing version check endpoint to all authenticated users will be useful for checking if the plugin is installed by non-admin accounts also.
  * Enable/Disable crawl features based on the plugin version

* Note that only authenticated users can access this resource: https://docs.atlassian.com/DAC/javadoc/rest/2.2/reference/com/atlassian/plugins/rest/common/security/AnonymousAllowed.html
* Tested on our confluence instance 