### PR TITLE
[Confluence Plugin] Add info endpoint in plugin

### DIFF
--- a/confluence/server/scio_search/pom.xml
+++ b/confluence/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.askscio.atlassian_plugins.confluence</groupId>
   <artifactId>glean_search</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
 
   <organization>
     <name>Glean</name>

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/MyPluginComponentImpl.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/MyPluginComponentImpl.java
@@ -8,6 +8,8 @@ public class MyPluginComponentImpl implements MyPluginComponent {
   public static final String TARGET_CONFIG_KEY =
       "com.askscio.atlassian_plugins.confluence.targetURL";
   public static final String PLUGIN_STATUS_KEY = "com.askscio.atlassian_plugins.confluence.status";
+  public static final String PLUGIN_STATUS_LAST_UPDATED_KEY =
+      "com.askscio.atlassian_plugins.confluence.status.lastUpdated";
   private final ApplicationProperties applicationProperties;
 
   public MyPluginComponentImpl(final ApplicationProperties applicationProperties) {

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/MyPluginComponentImpl.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/MyPluginComponentImpl.java
@@ -4,13 +4,10 @@ import com.askscio.atlassian_plugins.confluence.api.MyPluginComponent;
 import com.atlassian.sal.api.ApplicationProperties;
 
 public class MyPluginComponentImpl implements MyPluginComponent {
+
   public static final String TARGET_CONFIG_KEY =
       "com.askscio.atlassian_plugins.confluence.targetURL";
-  public static final String LAST_WEBHOOK_RESPONSE_TIME_KEY = "com.askscio.atlassian_plugins.confluence.lastWebhookResponseTime";
-  public static final String LAST_WEBHOOK_RESPONSE_CODE_KEY = "com.askscio.atlassian_plugins.confluence.lastWebhookResponseCode";
-  public static final String LAST_WEBHOOK_SUCCESS_TIME_KEY = "com.askscio.atlassian_plugins.confluence.lastWebhookSuccessTime";
-  public static final String LAST_WEBHOOK_FAILURE_TIME_KEY = "com.askscio.atlassian_plugins.confluence.lastWebhookFailureTime";
-
+  public static final String PLUGIN_STATUS_KEY = "com.askscio.atlassian_plugins.confluence.status";
   private final ApplicationProperties applicationProperties;
 
   public MyPluginComponentImpl(final ApplicationProperties applicationProperties) {

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/MyPluginComponentImpl.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/MyPluginComponentImpl.java
@@ -6,6 +6,11 @@ import com.atlassian.sal.api.ApplicationProperties;
 public class MyPluginComponentImpl implements MyPluginComponent {
   public static final String TARGET_CONFIG_KEY =
       "com.askscio.atlassian_plugins.confluence.targetURL";
+  public static final String LAST_WEBHOOK_RESPONSE_TIME_KEY = "com.askscio.atlassian_plugins.confluence.lastWebhookResponseTime";
+  public static final String LAST_WEBHOOK_RESPONSE_CODE_KEY = "com.askscio.atlassian_plugins.confluence.lastWebhookResponseCode";
+  public static final String LAST_WEBHOOK_SUCCESS_TIME_KEY = "com.askscio.atlassian_plugins.confluence.lastWebhookSuccessTime";
+  public static final String LAST_WEBHOOK_FAILURE_TIME_KEY = "com.askscio.atlassian_plugins.confluence.lastWebhookFailureTime";
+
   private final ApplicationProperties applicationProperties;
 
   public MyPluginComponentImpl(final ApplicationProperties applicationProperties) {

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoFetch.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoFetch.java
@@ -43,7 +43,7 @@ public class ScioSearchInfoFetch {
   public ScioSearchInfoResponse getInfo(
       @QueryParam("getInstalledPlugins") boolean getInstalledPlugins) {
     final UserInfo userInfo = new UserInfo(userManager);
-    final InstanceInfo instanceInfo = new InstanceInfo(settingsManager, pluginAccessor,
+    final InstanceInfo instanceInfo = new InstanceInfo(settingsManager, pluginAccessor, userManager,
         getInstalledPlugins);
     final PluginInfo pluginInfo = new PluginInfo(pluginAccessor, pluginSettingsFactory);
     return new ScioSearchInfoResponse(userInfo, instanceInfo, pluginInfo);

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoFetch.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoFetch.java
@@ -1,0 +1,51 @@
+package com.askscio.atlassian_plugins.confluence.impl;
+
+import com.askscio.atlassian_plugins.confluence.impl.ScioSearchInfoResponse.InstanceInfo;
+import com.askscio.atlassian_plugins.confluence.impl.ScioSearchInfoResponse.PluginInfo;
+import com.askscio.atlassian_plugins.confluence.impl.ScioSearchInfoResponse.UserInfo;
+import com.atlassian.confluence.setup.settings.SettingsManager;
+import com.atlassian.plugin.PluginAccessor;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.sal.api.user.UserManager;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Named
+@Path("/info")
+public class ScioSearchInfoFetch {
+
+  @ConfluenceImport
+  private final UserManager userManager;
+  @ConfluenceImport
+  private final SettingsManager settingsManager;
+  @ConfluenceImport
+  private final PluginAccessor pluginAccessor;
+  @ConfluenceImport
+  private final PluginSettingsFactory pluginSettingsFactory;
+
+  @Inject
+  public ScioSearchInfoFetch(UserManager userManager, SettingsManager settingsManager,
+      PluginAccessor pluginAccessor, PluginSettingsFactory pluginSettingsFactory) {
+    this.userManager = userManager;
+    this.settingsManager = settingsManager;
+    this.pluginAccessor = pluginAccessor;
+    this.pluginSettingsFactory = pluginSettingsFactory;
+  }
+
+  @GET
+  @Produces({MediaType.APPLICATION_JSON})
+  public ScioSearchInfoResponse getInfo(
+      @QueryParam("getInstalledPlugins") boolean getInstalledPlugins) {
+    final UserInfo userInfo = new UserInfo(userManager);
+    final InstanceInfo instanceInfo = new InstanceInfo(settingsManager, pluginAccessor,
+        getInstalledPlugins);
+    final PluginInfo pluginInfo = new PluginInfo(pluginAccessor, pluginSettingsFactory);
+    return new ScioSearchInfoResponse(userInfo, instanceInfo, pluginInfo);
+  }
+}

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoFetch.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoFetch.java
@@ -1,7 +1,7 @@
 package com.askscio.atlassian_plugins.confluence.impl;
 
 import com.askscio.atlassian_plugins.confluence.impl.ScioSearchInfoResponse.InstanceInfo;
-import com.askscio.atlassian_plugins.confluence.impl.ScioSearchInfoResponse.PluginInfo;
+import com.askscio.atlassian_plugins.confluence.impl.ScioSearchInfoResponse.ScioPluginInfo;
 import com.askscio.atlassian_plugins.confluence.impl.ScioSearchInfoResponse.UserInfo;
 import com.atlassian.confluence.setup.settings.SettingsManager;
 import com.atlassian.plugin.PluginAccessor;
@@ -45,7 +45,7 @@ public class ScioSearchInfoFetch {
     final UserInfo userInfo = new UserInfo(userManager);
     final InstanceInfo instanceInfo = new InstanceInfo(settingsManager, pluginAccessor, userManager,
         getInstalledPlugins);
-    final PluginInfo pluginInfo = new PluginInfo(pluginAccessor, pluginSettingsFactory);
-    return new ScioSearchInfoResponse(userInfo, instanceInfo, pluginInfo);
+    final ScioPluginInfo scioPluginInfo = new ScioPluginInfo(pluginAccessor, pluginSettingsFactory);
+    return new ScioSearchInfoResponse(userInfo, instanceInfo, scioPluginInfo);
   }
 }

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoFetch.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoFetch.java
@@ -13,7 +13,6 @@ import javax.inject.Named;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 @Named
@@ -40,11 +39,9 @@ public class ScioSearchInfoFetch {
 
   @GET
   @Produces({MediaType.APPLICATION_JSON})
-  public ScioSearchInfoResponse getInfo(
-      @QueryParam("getInstalledPlugins") boolean getInstalledPlugins) {
+  public ScioSearchInfoResponse getInfo() {
     final UserInfo userInfo = new UserInfo(userManager);
-    final InstanceInfo instanceInfo = new InstanceInfo(settingsManager, pluginAccessor, userManager,
-        getInstalledPlugins);
+    final InstanceInfo instanceInfo = new InstanceInfo(settingsManager);
     final ScioPluginInfo scioPluginInfo = new ScioPluginInfo(pluginAccessor, pluginSettingsFactory);
     return new ScioSearchInfoResponse(userInfo, instanceInfo, scioPluginInfo);
   }

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoResponse.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoResponse.java
@@ -51,7 +51,7 @@ public class ScioSearchInfoResponse {
       this.userName = profile.getUsername();
       this.fullName = profile.getFullName();
       this.email = profile.getEmail();
-      this.isAdmin = userManager.isSystemAdmin(profile.getUserKey());
+      this.isAdmin = Utils.isCurrentUserAdmin(userManager);
     }
   }
 
@@ -63,10 +63,11 @@ public class ScioSearchInfoResponse {
     private final List<InstalledPluginInfo> installedPluginInfos;
 
     public InstanceInfo(SettingsManager settingsManager, PluginAccessor pluginAccessor,
+        UserManager userManager,
         boolean getInstalledPlugins) {
       this.version = GeneralUtil.getVersionNumber();
       this.baseUrl = settingsManager.getGlobalSettings().getBaseUrl();
-      if (getInstalledPlugins) {
+      if (getInstalledPlugins && Utils.isCurrentUserAdmin(userManager)) {
         this.installedPluginInfos = new ArrayList<>();
         Collection<Plugin> installedPlugins = pluginAccessor.getPlugins();
         for (Plugin plugin : installedPlugins) {

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoResponse.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoResponse.java
@@ -1,0 +1,130 @@
+package com.askscio.atlassian_plugins.confluence.impl;
+
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_FAILURE_TIME_KEY;
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_RESPONSE_CODE_KEY;
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_RESPONSE_TIME_KEY;
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_SUCCESS_TIME_KEY;
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.TARGET_CONFIG_KEY;
+import static com.askscio.atlassian_plugins.confluence.impl.Utils.getPluginSettingsValueOrElse;
+
+import com.atlassian.confluence.setup.settings.SettingsManager;
+import com.atlassian.confluence.util.GeneralUtil;
+import com.atlassian.plugin.Plugin;
+import com.atlassian.plugin.PluginAccessor;
+import com.atlassian.plugin.PluginInformation;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.sal.api.user.UserProfile;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+public class ScioSearchInfoResponse {
+
+  private final UserInfo userInfo;
+  private final InstanceInfo instanceInfo;
+  private final PluginInfo pluginInfo;
+
+  public ScioSearchInfoResponse(UserInfo userInfo, InstanceInfo instanceInfo,
+      PluginInfo pluginInfo) {
+    this.userInfo = userInfo;
+    this.instanceInfo = instanceInfo;
+    this.pluginInfo = pluginInfo;
+  }
+
+  @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+  public static class UserInfo {
+
+    private final String userKey;
+    private final String userName;
+    private final String fullName;
+    private final String email;
+    private final boolean isAdmin;
+
+    public UserInfo(UserManager userManager) {
+      final UserProfile profile = userManager.getRemoteUser();
+      this.userKey = profile.getUserKey().getStringValue();
+      this.userName = profile.getUsername();
+      this.fullName = profile.getFullName();
+      this.email = profile.getEmail();
+      this.isAdmin = userManager.isSystemAdmin(profile.getUserKey());
+    }
+  }
+
+  @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+  public static class InstanceInfo {
+
+    private final String version;
+    private final String baseUrl;
+    private final List<InstalledPluginInfo> installedPluginInfos;
+
+    public InstanceInfo(SettingsManager settingsManager, PluginAccessor pluginAccessor,
+        boolean getInstalledPlugins) {
+      this.version = GeneralUtil.getVersionNumber();
+      this.baseUrl = settingsManager.getGlobalSettings().getBaseUrl();
+      if (getInstalledPlugins) {
+        this.installedPluginInfos = new ArrayList<>();
+        Collection<Plugin> installedPlugins = pluginAccessor.getPlugins();
+        for (Plugin plugin : installedPlugins) {
+          InstalledPluginInfo installedPluginInfo = new InstalledPluginInfo(pluginAccessor, plugin);
+          this.installedPluginInfos.add(installedPluginInfo);
+        }
+      } else {
+        this.installedPluginInfos = null;
+      }
+    }
+
+    @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+    public static class InstalledPluginInfo {
+
+      private final String name;
+      private final String key;
+      private final String description;
+      private final String vendorName;
+      private final String vendorUrl;
+      private final String version;
+      private final boolean isEnabled;
+
+      public InstalledPluginInfo(PluginAccessor accessor, Plugin plugin) {
+        PluginInformation pluginInformation = plugin.getPluginInformation();
+        this.name = plugin.getName();
+        this.key = plugin.getKey();
+        this.description = pluginInformation.getDescription();
+        this.vendorName = pluginInformation.getVendorName();
+        this.vendorUrl = pluginInformation.getVendorUrl();
+        this.version = pluginInformation.getVersion();
+        this.isEnabled = accessor.isPluginEnabled(plugin.getKey());
+      }
+    }
+  }
+
+  @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+  public static class PluginInfo {
+
+    private final String version;
+    private final String target;
+    private final String lastWebhookResponseTime;
+    private final String lastWebhookResponseCode;
+    private final String lastWebhookSuccessTime;
+    private final String lastWebhookFailureTime;
+
+    public PluginInfo(PluginAccessor pluginAccessor, PluginSettingsFactory pluginSettingsFactory) {
+      final PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
+      this.version = pluginAccessor.getPlugin(Constants.PLUGIN_KEY).getPluginInformation()
+          .getVersion();
+      this.target = (String) pluginSettings.get(TARGET_CONFIG_KEY);
+      this.lastWebhookResponseTime = getPluginSettingsValueOrElse(pluginSettings,
+          LAST_WEBHOOK_RESPONSE_TIME_KEY, "Never fired");
+      this.lastWebhookResponseCode = getPluginSettingsValueOrElse(pluginSettings,
+          LAST_WEBHOOK_RESPONSE_CODE_KEY, "Never fired");
+      this.lastWebhookSuccessTime = getPluginSettingsValueOrElse(pluginSettings,
+          LAST_WEBHOOK_SUCCESS_TIME_KEY, "Never succeeded");
+      this.lastWebhookFailureTime = getPluginSettingsValueOrElse(pluginSettings,
+          LAST_WEBHOOK_FAILURE_TIME_KEY, "Never failed");
+    }
+  }
+}

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoResponse.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchInfoResponse.java
@@ -8,14 +8,10 @@ import com.atlassian.confluence.util.GeneralUtil;
 import com.atlassian.extras.common.log.Logger;
 import com.atlassian.plugin.Plugin;
 import com.atlassian.plugin.PluginAccessor;
-import com.atlassian.plugin.PluginInformation;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import org.codehaus.jackson.annotate.JsonAutoDetect;
 import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
 
@@ -58,46 +54,10 @@ public class ScioSearchInfoResponse {
 
     private final String version;
     private final String baseUrl;
-    private final List<InstalledPluginInfo> installedPluginInfos;
 
-    public InstanceInfo(SettingsManager settingsManager, PluginAccessor pluginAccessor,
-        UserManager userManager,
-        boolean getInstalledPlugins) {
+    public InstanceInfo(SettingsManager settingsManager) {
       this.version = GeneralUtil.getVersionNumber();
       this.baseUrl = settingsManager.getGlobalSettings().getBaseUrl();
-      if (getInstalledPlugins && Utils.isCurrentUserAdmin(userManager)) {
-        this.installedPluginInfos = new ArrayList<>();
-        Collection<Plugin> installedPlugins = pluginAccessor.getPlugins();
-        for (Plugin plugin : installedPlugins) {
-          InstalledPluginInfo installedPluginInfo = new InstalledPluginInfo(pluginAccessor, plugin);
-          this.installedPluginInfos.add(installedPluginInfo);
-        }
-      } else {
-        this.installedPluginInfos = null;
-      }
-    }
-
-    @JsonAutoDetect(fieldVisibility = Visibility.ANY)
-    public static class InstalledPluginInfo {
-
-      private final String name;
-      private final String key;
-      private final String description;
-      private final String vendorName;
-      private final String vendorUrl;
-      private final String version;
-      private final boolean isEnabled;
-
-      public InstalledPluginInfo(PluginAccessor accessor, Plugin plugin) {
-        PluginInformation pluginInformation = plugin.getPluginInformation();
-        this.name = plugin.getName();
-        this.key = plugin.getKey();
-        this.description = pluginInformation.getDescription();
-        this.vendorName = pluginInformation.getVendorName();
-        this.vendorUrl = pluginInformation.getVendorUrl();
-        this.version = pluginInformation.getVersion();
-        this.isEnabled = accessor.isPluginEnabled(plugin.getKey());
-      }
     }
   }
 

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchServletFilter.java
@@ -154,7 +154,8 @@ public class ScioSearchServletFilter implements Filter {
     }
     logger.debug(String.format("Visit url %s", visitUrl));
     try {
-      executor.submit(new ScioWebhookTask(target, visitUrl.toString(), user.getLowerName()));
+      executor.submit(new ScioWebhookTask(target, visitUrl.toString(), user.getLowerName(),
+          pluginSettings));
     } catch (RejectedExecutionException e) {
       logger.warn(String.format("Queue full: %s", e.getMessage()));
     }

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
@@ -1,20 +1,11 @@
 package com.askscio.atlassian_plugins.confluence.impl;
 
-import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_FAILURE_TIME_KEY;
-import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_RESPONSE_CODE_KEY;
-import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_RESPONSE_TIME_KEY;
-import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_SUCCESS_TIME_KEY;
-
 import com.atlassian.extras.common.log.Logger;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 
 public class ScioWebhookTask implements Runnable {
 
@@ -46,23 +37,14 @@ public class ScioWebhookTask implements Runnable {
       final byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
       output.write(bytes);
       int responseCode = connection.getResponseCode();
-      updatePluginStatus(responseCode);
+      try {
+        Utils.updatePluginStatus(pluginSettings, responseCode);
+      } catch (Exception e) {
+        logger.warn(String.format("Exception while updating plugin status: %s", e));
+      }
       logger.debug(String.format("Webhook sent %d", responseCode));
     } catch (Exception e) {
       logger.warn(String.format("Failed to send Scio webhook: %s", e));
-    }
-  }
-
-  private void updatePluginStatus(int responseCode) {
-    DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(
-        ZoneId.from(ZoneOffset.UTC));
-    String currentTime = formatter.format(Instant.now());
-    pluginSettings.put(LAST_WEBHOOK_RESPONSE_TIME_KEY, currentTime);
-    pluginSettings.put(LAST_WEBHOOK_RESPONSE_CODE_KEY, String.valueOf(responseCode));
-    if (responseCode >= 200 & responseCode < 300) {
-      pluginSettings.put(LAST_WEBHOOK_SUCCESS_TIME_KEY, currentTime);
-    } else if (responseCode >= 400) {
-      pluginSettings.put(LAST_WEBHOOK_FAILURE_TIME_KEY, currentTime);
     }
   }
 }

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
@@ -1,10 +1,20 @@
 package com.askscio.atlassian_plugins.confluence.impl;
 
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_FAILURE_TIME_KEY;
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_RESPONSE_CODE_KEY;
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_RESPONSE_TIME_KEY;
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.LAST_WEBHOOK_SUCCESS_TIME_KEY;
+
+import com.atlassian.extras.common.log.Logger;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import com.atlassian.extras.common.log.Logger;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 public class ScioWebhookTask implements Runnable {
 
@@ -13,11 +23,14 @@ public class ScioWebhookTask implements Runnable {
   private final String target;
   private final String visitedUrl;
   private final String user;
+  private final PluginSettings pluginSettings;
 
-  public ScioWebhookTask(String target, String visitedUrl, String user) {
+  public ScioWebhookTask(String target, String visitedUrl, String user,
+      PluginSettings pluginSettings) {
     this.target = target;
     this.visitedUrl = visitedUrl;
     this.user = user;
+    this.pluginSettings = pluginSettings;
   }
 
   @Override
@@ -32,9 +45,24 @@ public class ScioWebhookTask implements Runnable {
       final String json = String.format("{\"url\":\"%s\",\"user\":\"%s\"}", visitedUrl, user);
       final byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
       output.write(bytes);
-      logger.debug(String.format("Webhook sent %d", connection.getResponseCode()));
+      int responseCode = connection.getResponseCode();
+      updatePluginStatus(responseCode);
+      logger.debug(String.format("Webhook sent %d", responseCode));
     } catch (Exception e) {
       logger.warn(String.format("Failed to send Scio webhook: %s", e));
+    }
+  }
+
+  private void updatePluginStatus(int responseCode) {
+    DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(
+        ZoneId.from(ZoneOffset.UTC));
+    String currentTime = formatter.format(Instant.now());
+    pluginSettings.put(LAST_WEBHOOK_RESPONSE_TIME_KEY, currentTime);
+    pluginSettings.put(LAST_WEBHOOK_RESPONSE_CODE_KEY, String.valueOf(responseCode));
+    if (responseCode >= 200 & responseCode < 300) {
+      pluginSettings.put(LAST_WEBHOOK_SUCCESS_TIME_KEY, currentTime);
+    } else if (responseCode >= 400) {
+      pluginSettings.put(LAST_WEBHOOK_FAILURE_TIME_KEY, currentTime);
     }
   }
 }

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
@@ -1,11 +1,13 @@
 package com.askscio.atlassian_plugins.confluence.impl;
 
+import com.atlassian.cache.Cache;
 import com.atlassian.extras.common.log.Logger;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 public class ScioWebhookTask implements Runnable {
 
@@ -15,13 +17,15 @@ public class ScioWebhookTask implements Runnable {
   private final String visitedUrl;
   private final String user;
   private final PluginSettings pluginSettings;
+  private final Cache<String, Optional<String>> pluginSettingsCache;
 
   public ScioWebhookTask(String target, String visitedUrl, String user,
-      PluginSettings pluginSettings) {
+      PluginSettings pluginSettings, Cache<String, Optional<String>> pluginSettingsCache) {
     this.target = target;
     this.visitedUrl = visitedUrl;
     this.user = user;
     this.pluginSettings = pluginSettings;
+    this.pluginSettingsCache = pluginSettingsCache;
   }
 
   @Override
@@ -38,7 +42,7 @@ public class ScioWebhookTask implements Runnable {
       output.write(bytes);
       int responseCode = connection.getResponseCode();
       try {
-        Utils.updatePluginStatus(pluginSettings, responseCode);
+        Utils.updatePluginStatus(pluginSettingsCache, pluginSettings, responseCode);
       } catch (Exception e) {
         logger.warn(String.format("Exception while updating plugin status: %s", e));
       }

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Utils.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Utils.java
@@ -1,0 +1,11 @@
+package com.askscio.atlassian_plugins.confluence.impl;
+
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+
+public class Utils {
+  public static String getPluginSettingsValueOrElse(PluginSettings pluginSettings,
+      String pluginSettingsKey, String orElse) {
+    String val = (String) pluginSettings.get(pluginSettingsKey);
+    return val != null ? val : orElse;
+  }
+}

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Utils.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Utils.java
@@ -1,11 +1,25 @@
 package com.askscio.atlassian_plugins.confluence.impl;
 
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.sal.api.user.UserProfile;
 
 public class Utils {
+
   public static String getPluginSettingsValueOrElse(PluginSettings pluginSettings,
       String pluginSettingsKey, String orElse) {
     String val = (String) pluginSettings.get(pluginSettingsKey);
     return val != null ? val : orElse;
+  }
+
+  public static boolean isCurrentUserAdmin(UserManager userManager) {
+    final UserProfile profile = userManager.getRemoteUser();
+    return profile != null && userManager.isSystemAdmin(profile.getUserKey());
+  }
+
+  public static void validateUserIsAdmin(UserManager userManager) {
+    if (!isCurrentUserAdmin(userManager)) {
+      throw new UnauthorizedException("Unauthorized");
+    }
   }
 }

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Utils.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Utils.java
@@ -1,21 +1,32 @@
 package com.askscio.atlassian_plugins.confluence.impl;
 
 import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.PLUGIN_STATUS_KEY;
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.PLUGIN_STATUS_LAST_UPDATED_KEY;
 
+import com.atlassian.cache.Cache;
+import com.atlassian.cache.CacheLoader;
+import com.atlassian.extras.common.log.Logger;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
 import com.google.gson.Gson;
+import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 import org.codehaus.jackson.annotate.JsonAutoDetect;
 import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
 
 public class Utils {
 
+  private static final Logger.Log logger = Logger.getInstance(Utils.class);
   private static final Gson gson = new Gson();
+  private static final int PLUGIN_STATUS_UPDATE_INTERVAL_SECONDS = 60; // in seconds
+  private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(
+      ZoneId.from(ZoneOffset.UTC));
 
   public static boolean isCurrentUserAdmin(UserManager userManager) {
     final UserProfile profile = userManager.getRemoteUser();
@@ -29,29 +40,48 @@ public class Utils {
   }
 
   public static PluginStatus getPluginStatus(PluginSettings pluginSettings) {
-    if (pluginSettings.get(PLUGIN_STATUS_KEY) == null) {
+    String pluginStatusStr = (String) pluginSettings.get(PLUGIN_STATUS_KEY);
+    if (pluginStatusStr == null) {
       return new PluginStatus();
     }
-    return gson.fromJson((String) pluginSettings.get(PLUGIN_STATUS_KEY), PluginStatus.class);
+    return gson.fromJson(pluginStatusStr, PluginStatus.class);
   }
 
-  public static void updatePluginStatus(PluginSettings pluginSettings, int responseCode) {
-    DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(
-        ZoneId.from(ZoneOffset.UTC));
-    String currentTime = formatter.format(Instant.now());
-    PluginStatus pluginStatus = getPluginStatus(pluginSettings);
-    pluginStatus.lastWebhookResponseTime = currentTime;
+  public static void updatePluginStatus(Cache<String, Optional<String>> pluginSettingsCache,
+      PluginSettings pluginSettings,
+      int responseCode) {
+    String pluginStatusStr = pluginSettingsCache.get(PLUGIN_STATUS_KEY).orElse(null);
+    PluginStatus pluginStatus = pluginStatusStr == null ? new PluginStatus() : gson.fromJson(
+        pluginStatusStr, PluginStatus.class);
+    String currentTimeStr = formatter.format(Instant.now());
+    pluginStatus.lastWebhookResponseTime = currentTimeStr;
     pluginStatus.lastWebhookResponseCode = String.valueOf(responseCode);
     if (responseCode >= 200 & responseCode < 300) {
-      pluginStatus.lastWebhookSuccessTime = currentTime;
+      pluginStatus.lastWebhookSuccessTime = currentTimeStr;
     } else if (responseCode >= 400) {
-      pluginStatus.lastWebhookFailureTime = currentTime;
+      pluginStatus.lastWebhookFailureTime = currentTimeStr;
     }
-    pluginSettings.put(PLUGIN_STATUS_KEY, gson.toJson(pluginStatus));
+    pluginSettingsCache.put(PLUGIN_STATUS_KEY, Optional.of(gson.toJson(pluginStatus)));
+    persistInPluginSettingsIfNecessary(pluginSettingsCache, pluginSettings, pluginStatus);
+  }
+
+  private static void persistInPluginSettingsIfNecessary(Cache<String, Optional<String>> cache,
+      PluginSettings pluginSettings,
+      PluginStatus pluginStatus) {
+    String pluginStatusLastUpdatedStr = cache.get(PLUGIN_STATUS_LAST_UPDATED_KEY).orElse(null);
+    Instant pluginStatusLastUpdated =
+        pluginStatusLastUpdatedStr == null ? Instant.EPOCH : Instant.parse(
+            pluginStatusLastUpdatedStr);
+    Instant now = Instant.now();
+    long secondsSinceLastUpdate = pluginStatusLastUpdated.until(now, ChronoUnit.SECONDS);
+    if (secondsSinceLastUpdate > PLUGIN_STATUS_UPDATE_INTERVAL_SECONDS) {
+      cache.put(PLUGIN_STATUS_LAST_UPDATED_KEY, Optional.of(now.toString()));
+      pluginSettings.put(PLUGIN_STATUS_KEY, gson.toJson(pluginStatus));
+    }
   }
 
   @JsonAutoDetect(fieldVisibility = Visibility.ANY)
-  public static class PluginStatus {
+  public static class PluginStatus implements Serializable {
 
     public String lastWebhookResponseTime;
     public String lastWebhookResponseCode;
@@ -63,6 +93,20 @@ public class Utils {
       lastWebhookResponseCode = "Never fired";
       lastWebhookSuccessTime = "Never succeeded";
       lastWebhookFailureTime = "Never failed";
+    }
+  }
+
+  public static class PluginSettingsCacheLoader implements CacheLoader<String, Optional<String>> {
+
+    private final PluginSettings pluginSettings;
+
+    PluginSettingsCacheLoader(PluginSettings pluginSettings) {
+      this.pluginSettings = pluginSettings;
+    }
+
+    @Override
+    public Optional<String> load(String key) {
+      return Optional.ofNullable((String) pluginSettings.get(key));
     }
   }
 }

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Utils.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/Utils.java
@@ -1,16 +1,21 @@
 package com.askscio.atlassian_plugins.confluence.impl;
 
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.PLUGIN_STATUS_KEY;
+
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
+import com.google.gson.Gson;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
 
 public class Utils {
 
-  public static String getPluginSettingsValueOrElse(PluginSettings pluginSettings,
-      String pluginSettingsKey, String orElse) {
-    String val = (String) pluginSettings.get(pluginSettingsKey);
-    return val != null ? val : orElse;
-  }
+  private static final Gson gson = new Gson();
 
   public static boolean isCurrentUserAdmin(UserManager userManager) {
     final UserProfile profile = userManager.getRemoteUser();
@@ -20,6 +25,44 @@ public class Utils {
   public static void validateUserIsAdmin(UserManager userManager) {
     if (!isCurrentUserAdmin(userManager)) {
       throw new UnauthorizedException("Unauthorized");
+    }
+  }
+
+  public static PluginStatus getPluginStatus(PluginSettings pluginSettings) {
+    if (pluginSettings.get(PLUGIN_STATUS_KEY) == null) {
+      return new PluginStatus();
+    }
+    return gson.fromJson((String) pluginSettings.get(PLUGIN_STATUS_KEY), PluginStatus.class);
+  }
+
+  public static void updatePluginStatus(PluginSettings pluginSettings, int responseCode) {
+    DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(
+        ZoneId.from(ZoneOffset.UTC));
+    String currentTime = formatter.format(Instant.now());
+    PluginStatus pluginStatus = getPluginStatus(pluginSettings);
+    pluginStatus.lastWebhookResponseTime = currentTime;
+    pluginStatus.lastWebhookResponseCode = String.valueOf(responseCode);
+    if (responseCode >= 200 & responseCode < 300) {
+      pluginStatus.lastWebhookSuccessTime = currentTime;
+    } else if (responseCode >= 400) {
+      pluginStatus.lastWebhookFailureTime = currentTime;
+    }
+    pluginSettings.put(PLUGIN_STATUS_KEY, gson.toJson(pluginStatus));
+  }
+
+  @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+  public static class PluginStatus {
+
+    public String lastWebhookResponseTime;
+    public String lastWebhookResponseCode;
+    public String lastWebhookSuccessTime;
+    public String lastWebhookFailureTime;
+
+    public PluginStatus() {
+      lastWebhookResponseTime = "Never fired";
+      lastWebhookResponseCode = "Never fired";
+      lastWebhookSuccessTime = "Never succeeded";
+      lastWebhookFailureTime = "Never failed";
     }
   }
 }


### PR DESCRIPTION
* This change adds a new `/info` endpoint that can be called by any logged in user.
* By default it returns the following fields:
  * User Info: Returns information regarding the logged in user such as name, key, email, isAdmin, etc.
  * Instance info: Returns information regarding the Confluence Server instance such as version, baseUrl, etc.
  * Plugin info: Returns information regarding the Scio plugin such as target, version, lastResponseCode, lastSuccessTime, lastFailureTime, etc.

- [x] Test locally
- [x] Test on actual instance