### PR TITLE
[Confluence Plugin] Add target url configuration UI to plugin

### DIFF
--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchConfigAction.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchConfigAction.java
@@ -7,6 +7,8 @@ import com.atlassian.confluence.security.SpacePermission;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.sal.api.websudo.WebSudoRequired;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 
 @WebSudoRequired
@@ -45,7 +47,19 @@ public class ScioSearchConfigAction extends ConfluenceActionSupport {
 
   public String execute() throws Exception {
     PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
+    String targetUrl = getTarget();
+    if (targetUrl == null || targetUrl.isEmpty()) {
+      addFieldError("scio_search.target", "Target URL is required", null);
+      return ConfluenceActionSupport.ERROR;
+    }
+    try {
+      new URL(targetUrl);
+    } catch (MalformedURLException e) {
+      addFieldError("scio_search.target", "Invalid target URL", null);
+      return ConfluenceActionSupport.ERROR;
+    }
     pluginSettings.put(TARGET_CONFIG_KEY, getTarget());
+    addActionMessage("Target URL updated to " + targetUrl);
     return ConfluenceActionSupport.SUCCESS;
   }
 }

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchConfigAction.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchConfigAction.java
@@ -1,0 +1,51 @@
+package com.askscio.atlassian_plugins.confluence.impl;
+
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.TARGET_CONFIG_KEY;
+
+import com.atlassian.confluence.core.ConfluenceActionSupport;
+import com.atlassian.confluence.security.SpacePermission;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.sal.api.websudo.WebSudoRequired;
+import java.util.List;
+
+@WebSudoRequired
+public class ScioSearchConfigAction extends ConfluenceActionSupport {
+
+  private PluginSettingsFactory pluginSettingsFactory;
+
+  private String target;
+
+  public String getTarget() {
+    return target;
+  }
+
+  public void setTarget(String target) {
+    this.target = target;
+  }
+
+  public void setPluginSettingsFactory(PluginSettingsFactory pluginSettingsFactory) {
+    this.pluginSettingsFactory = pluginSettingsFactory;
+  }
+
+
+  @Override
+  protected List<String> getPermissionTypes() {
+    List<String> requiredPermissions = super.getPermissionTypes();
+    requiredPermissions.add(SpacePermission.CONFLUENCE_ADMINISTRATOR_PERMISSION);
+    return requiredPermissions;
+  }
+
+  @Override
+  public String doDefault() throws Exception {
+    PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
+    setTarget((String) pluginSettings.get(TARGET_CONFIG_KEY));
+    return super.doDefault();
+  }
+
+  public String execute() throws Exception {
+    PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
+    pluginSettings.put(TARGET_CONFIG_KEY, getTarget());
+    return ConfluenceActionSupport.SUCCESS;
+  }
+}

--- a/confluence/server/scio_search/src/main/resources/atlassian-plugin.xml
+++ b/confluence/server/scio_search/src/main/resources/atlassian-plugin.xml
@@ -1,38 +1,56 @@
 <atlassian-plugin key="${atlassian.plugin.key}" name="${project.name}" plugins-version="2">
   <plugin-info>
     <description>${project.description}</description>
-    <version>${project.version}</version>
-    <vendor name="${project.organization.name}" url="${project.organization.url}"/>
     <param name="atlassian-data-center-status">compatible</param>
     <param name="atlassian-data-center-compatible">true</param>
     <param name="read-only-access-mode-compatible">true</param>
     <param name="plugin-type">both</param>
     <param name="plugin-icon">images/pluginIcon.png</param>
     <param name="plugin-logo">images/pluginLogo.png</param>
+    <param name="configure.url">/admin/plugins/scio_search/scio-search-configure.action</param>
+    <vendor name="${project.organization.name}" url="${project.organization.url}"/>
+    <version>${project.version}</version>
   </plugin-info>
 
   <!-- add our i18n resource -->
-  <resource type="i18n" name="i18n" location="scio_search"/>
+  <resource location="scio_search" name="i18n" type="i18n"/>
 
   <!-- add our web resources -->
-  <web-resource key="scio_search-resources" name="scio_search Web Resources">
-    <dependency>com.atlassian.auiplugin:ajs</dependency>
-
-    <resource type="download" name="scio_search.css" location="/css/scio_search.css"/>
-    <resource type="download" name="scio_search.js" location="/js/scio_search.js"/>
-    <resource type="download" name="images/" location="/images"/>
-
-    <context>scio_search</context>
-  </web-resource>
-
-  <servlet-filter key="scioSearchServletFilter"
-    class="com.askscio.atlassian_plugins.confluence.impl.ScioSearchServletFilter">
-    <description>Updates Scio ranking signals based on URLs visited.</description>
-    <url-pattern>*</url-pattern>
-  </servlet-filter>
-
   <rest key="scioSearchConfigRest" path="/scio_search" version="1.0">
     <description>Provides Scio Search plugin configuration endpoint.</description>
   </rest>
 
+  <servlet-filter class="com.askscio.atlassian_plugins.confluence.impl.ScioSearchServletFilter"
+    key="scioSearchServletFilter">
+    <description>Updates Scio ranking signals based on URLs visited.</description>
+    <url-pattern>*</url-pattern>
+  </servlet-filter>
+
+
+  <web-resource key="scio_search-resources" name="scio_search Web Resources">
+    <context>scio_search</context>
+
+    <dependency>com.atlassian.auiplugin:ajs</dependency>
+    <resource location="/js/scio_search.js" name="scio_search.js" type="download"/>
+    <resource location="/images" name="images/" type="download"/>
+
+    <resource location="/css/scio_search.css" name="scio_search.css" type="download"/>
+  </web-resource>
+
+  <xwork key="scio-search-config-action" name="Scio Search Config Action">
+    <package extends="default" name="Scio Search Config Action Package"
+      namespace="/admin/plugins/scio_search">
+      <action class="com.askscio.atlassian_plugins.confluence.impl.ScioSearchConfigAction"
+        method="doDefault" name="scio-search-configure">
+        <interceptor-ref name="defaultStack"/>
+        <result name="input" type="velocity">/vm/configure.vm</result>
+      </action>
+      <action class="com.askscio.atlassian_plugins.confluence.impl.ScioSearchConfigAction"
+        method="execute" name="scio-search-do-configure">
+        <interceptor-ref name="validatingStack"/>
+        <param name="RequireSecurityToken">true</param>
+        <result name="success" type="velocity">/vm/configure.vm</result>
+      </action>
+    </package>
+  </xwork>
 </atlassian-plugin>

--- a/confluence/server/scio_search/src/main/resources/atlassian-plugin.xml
+++ b/confluence/server/scio_search/src/main/resources/atlassian-plugin.xml
@@ -50,6 +50,7 @@
         <interceptor-ref name="validatingStack"/>
         <param name="RequireSecurityToken">true</param>
         <result name="success" type="velocity">/vm/configure.vm</result>
+        <result name="error" type="velocity">/vm/configure.vm</result>
       </action>
     </package>
   </xwork>

--- a/confluence/server/scio_search/src/main/resources/vm/configure.vm
+++ b/confluence/server/scio_search/src/main/resources/vm/configure.vm
@@ -1,3 +1,5 @@
+#requireResource("com.atlassian.auiplugin:aui-message")
+
 <html>
 <head>
     <title>Configure Scio Search Plugin</title>
@@ -12,6 +14,13 @@
         <input class="button submit" type="submit" value="Submit">
 
         <div class="description">Configure target url for Scio Search plugin for sending the webhook events.</div>
+        #foreach ($error in $fieldErrors.get("scio_search.target")) <div class="error">$error</div> #end
     </form>
+
+    #if($actionMessages.size() > 0)
+        <div class="aui-message aui-message-success">
+            <p>#foreach($message in $actionMessages) $message<br/> #end</p>
+        </div>
+    #end
 </body>
 </html>

--- a/confluence/server/scio_search/src/main/resources/vm/configure.vm
+++ b/confluence/server/scio_search/src/main/resources/vm/configure.vm
@@ -1,0 +1,17 @@
+<html>
+<head>
+    <title>Configure Scio Search Plugin</title>
+</head>
+<body>
+    <form class="aui" name="scio-search-configure-form" method="POST" action="${req.contextPath}/admin/plugins/scio_search/scio-search-do-configure.action">
+        #form_xsrfToken()
+        <h2>Target URL</h2>
+
+        <input type="text" name="target" id="target" value="$generalUtil.htmlEncode( $target )" class="text">
+
+        <input class="button submit" type="submit" value="Submit">
+
+        <div class="description">Configure target url for Scio Search plugin for sending the webhook events.</div>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
* This change adds a UI for configuring the target url of the search plugin. Previously, this was done by exposing a HTTP endpoint for modifying the target url.

Screenshot:
<img width="494" alt="Screenshot 2023-02-23 at 9 55 53 AM" src="https://user-images.githubusercontent.com/110805075/220821673-f0ba2948-1dde-4bfe-abe9-fa867576b2c9.png">

- [x] Test locally
- [x] Test on actual instance
