### PR TITLE
[JIRA SERVER PLUGIN]: Add /info endpoint and userinfo in it

### DIFF
--- a/jira/server/scio_search/pom.xml
+++ b/jira/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.askscio.atlassian_plugins.jira</groupId>
     <artifactId>glean_search</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 
 
     <organization>

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchConfigRestPlugin.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchConfigRestPlugin.java
@@ -36,17 +36,10 @@ public class ScioSearchConfigRestPlugin {
     this.pluginSettingsFactory = pluginSettingsFactory;
   }
 
-  private void validateUserIsAdmin() {
-    final UserProfile profile = userManager.getRemoteUser();
-    if (profile == null || !userManager.isSystemAdmin(profile.getUserKey())) {
-      throw new UnauthorizedException("Unauthorized");
-    }
-  }
-
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   public ScioConfigResponse getTarget() {
-    validateUserIsAdmin();
+    Utils.validateUserIsAdmin(userManager);
     final PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
     final String target = (String) pluginSettings.get(TARGET_CONFIG_KEY);
     final ScioConfigResponse response = new ScioConfigResponse();
@@ -59,7 +52,7 @@ public class ScioSearchConfigRestPlugin {
   @Consumes(MediaType.APPLICATION_JSON)
   public ScioConfigResponse setTarget(ScioConfigRequest request) {
     logger.debug(String.format("Received request for setting target url: %s", request.getTarget()));
-    validateUserIsAdmin();
+    Utils.validateUserIsAdmin(userManager);
     try {
       new URL(request.getTarget());
     } catch (MalformedURLException e) {

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfo.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfo.java
@@ -1,0 +1,46 @@
+package ScioSearchConfigRestPlugin.impl;
+
+import ScioSearchConfigRestPlugin.impl.ScioSearchInfoResponse.UserInfo;
+import com.atlassian.jira.config.properties.ApplicationProperties;
+import com.atlassian.plugin.PluginAccessor;
+import com.atlassian.plugin.spring.scanner.annotation.imports.JiraImport;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.sal.api.user.UserProfile;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Named
+@Path("/info")
+public class ScioSearchInfo {
+  @JiraImport
+  private final UserManager userManager;
+
+  @Inject
+  public ScioSearchInfo(UserManager userManager) {
+    this.userManager = userManager;
+  }
+
+  private UserInfo getUserInfo() {
+    UserInfo userInfo = new UserInfo();
+    UserProfile profile = userManager.getRemoteUser();
+    userInfo.userKey = profile.getUserKey().getStringValue();
+    userInfo.userName = profile.getUsername();
+    userInfo.fullName = profile.getFullName();
+    userInfo.email = profile.getEmail();
+    userInfo.isAdmin = Utils.isCurrentUserAdmin(userManager);
+    return userInfo;
+  }
+
+  @GET
+  @Produces({MediaType.APPLICATION_JSON})
+  public ScioSearchInfoResponse getInfo() {
+    ScioSearchInfoResponse response = new ScioSearchInfoResponse();
+    response.userInfo = getUserInfo();
+    return response;
+  }
+}

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfoResponse.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfoResponse.java
@@ -1,0 +1,18 @@
+package ScioSearchConfigRestPlugin.impl;
+
+import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+public class ScioSearchInfoResponse {
+  public UserInfo userInfo;
+
+  @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+  public static class UserInfo {
+    public String userKey;
+    public String userName;
+    public String fullName;
+    public String email;
+    public boolean isAdmin;
+  }
+}

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/Utils.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/Utils.java
@@ -1,0 +1,17 @@
+package ScioSearchConfigRestPlugin.impl;
+
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.sal.api.user.UserProfile;
+
+public class Utils {
+  public static boolean isCurrentUserAdmin(UserManager userManager) {
+    final UserProfile profile = userManager.getRemoteUser();
+    return profile != null && userManager.isSystemAdmin(profile.getUserKey());
+  }
+
+  public static void validateUserIsAdmin(UserManager userManager) {
+    if (!isCurrentUserAdmin(userManager)) {
+      throw new UnauthorizedException("Unauthorized");
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a simple /info endpoint. As part of the response, we are reporting the requesting user's basic info.

```
curl --user 'samba:test' 'http://127.0.0.1:8080/rest/scio_search/1.0/info' | jq .
{
  "userInfo": {
    "userKey": "JIRAUSER10100",
    "userName": "samba",
    "fullName": "Samba Krishna",
    "email": "samba@domain.net",
    "isAdmin": false
  }
}
```
