### PR TITLE
[JIRA SERVER PLUGIN]: Add instance info to /info endpoint

### DIFF
--- a/jira/server/scio_search/pom.xml
+++ b/jira/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.askscio.atlassian_plugins.jira</groupId>
     <artifactId>glean_search</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
 
     <organization>

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfo.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfo.java
@@ -1,7 +1,9 @@
 package ScioSearchConfigRestPlugin.impl;
 
+import ScioSearchConfigRestPlugin.impl.ScioSearchInfoResponse.InstanceInfo;
 import ScioSearchConfigRestPlugin.impl.ScioSearchInfoResponse.UserInfo;
 import com.atlassian.jira.config.properties.ApplicationProperties;
+import com.atlassian.jira.util.BuildUtilsInfo;
 import com.atlassian.plugin.PluginAccessor;
 import com.atlassian.plugin.spring.scanner.annotation.imports.JiraImport;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
@@ -19,10 +21,19 @@ import javax.ws.rs.core.MediaType;
 public class ScioSearchInfo {
   @JiraImport
   private final UserManager userManager;
+  // Ref: https://docs.atlassian.com/software/jira/docs/api/7.6.1/com/atlassian/jira/issue/fields/rest/json/beans/JiraBaseUrls.html
+  @JiraImport
+  private final ApplicationProperties applicationProperties;
+  // Ref: https://docs.atlassian.com/software/jira/docs/api/7.6.1/com/atlassian/jira/util/BuildUtilsInfo.html
+  @JiraImport
+  private final BuildUtilsInfo buildUtilsInfo;
 
   @Inject
-  public ScioSearchInfo(UserManager userManager) {
+  public ScioSearchInfo(UserManager userManager, ApplicationProperties applicationProperties,
+      BuildUtilsInfo buildUtilsInfo) {
     this.userManager = userManager;
+    this.applicationProperties = applicationProperties;
+    this.buildUtilsInfo = buildUtilsInfo;
   }
 
   private UserInfo getUserInfo() {
@@ -36,11 +47,19 @@ public class ScioSearchInfo {
     return userInfo;
   }
 
+  private InstanceInfo getInstanceInfo() {
+    InstanceInfo instanceInfo = new InstanceInfo();
+    instanceInfo.baseUrl = applicationProperties.getDefaultBackedString("jira.baseurl");
+    instanceInfo.version = buildUtilsInfo.getVersion();
+    return instanceInfo;
+  }
+
   @GET
   @Produces({MediaType.APPLICATION_JSON})
   public ScioSearchInfoResponse getInfo() {
     ScioSearchInfoResponse response = new ScioSearchInfoResponse();
     response.userInfo = getUserInfo();
+    response.instanceInfo = getInstanceInfo();
     return response;
   }
 }

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfo.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfo.java
@@ -21,7 +21,7 @@ import javax.ws.rs.core.MediaType;
 public class ScioSearchInfo {
   @JiraImport
   private final UserManager userManager;
-  // Ref: https://docs.atlassian.com/software/jira/docs/api/7.6.1/com/atlassian/jira/issue/fields/rest/json/beans/JiraBaseUrls.html
+  // Ref: https://docs.atlassian.com/software/jira/docs/api/7.6.1/com/atlassian/jira/config/properties/ApplicationProperties.html
   @JiraImport
   private final ApplicationProperties applicationProperties;
   // Ref: https://docs.atlassian.com/software/jira/docs/api/7.6.1/com/atlassian/jira/util/BuildUtilsInfo.html

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfoResponse.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfoResponse.java
@@ -6,6 +6,7 @@ import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
 public class ScioSearchInfoResponse {
   public UserInfo userInfo;
+  public InstanceInfo instanceInfo;
 
   @JsonAutoDetect(fieldVisibility = Visibility.ANY)
   public static class UserInfo {
@@ -14,5 +15,11 @@ public class ScioSearchInfoResponse {
     public String fullName;
     public String email;
     public boolean isAdmin;
+  }
+
+  @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+  public static class InstanceInfo {
+    String version;
+    String baseUrl;
   }
 }


### PR DESCRIPTION
This PR adds basic server information to the `/info` endpoint response

```
curl --user 'user:test' 'http://127.0.0.1:8080/rest/scio_search/1.0/info' | jq .
{
  "userInfo": {
    "userKey": "JIRAUSER10100",
    "userName": "samba",
    "fullName": "Samba Krishna",
    "email": "samba@domain.net",
    "isAdmin": false
  },
  "instanceInfo": {
    "version": "9.0.0",
    "baseUrl": "http://jira-instance:8080"
  }
}
```