### PR TITLE
[JIRA SERVER PLUGIN] Add plugin info into /info response

### DIFF
--- a/jira/server/scio_search/pom.xml
+++ b/jira/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.askscio.atlassian_plugins.jira</groupId>
     <artifactId>glean_search</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 
 
     <organization>

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/Constants.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/Constants.java
@@ -1,0 +1,5 @@
+package ScioSearchConfigRestPlugin.impl;
+
+public class Constants {
+  public static final String PLUGIN_KEY = "com.askscio.atlassian_plugins.jira.glean_search";
+}

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfo.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfo.java
@@ -1,11 +1,16 @@
 package ScioSearchConfigRestPlugin.impl;
 
+import static ScioSearchConfigRestPlugin.impl.MyPluginComponentImpl.TARGET_CONFIG_KEY;
 import ScioSearchConfigRestPlugin.impl.ScioSearchInfoResponse.InstanceInfo;
+import ScioSearchConfigRestPlugin.impl.ScioSearchInfoResponse.ScioPluginInfo;
 import ScioSearchConfigRestPlugin.impl.ScioSearchInfoResponse.UserInfo;
+import com.atlassian.extras.common.log.Logger;
 import com.atlassian.jira.config.properties.ApplicationProperties;
 import com.atlassian.jira.util.BuildUtilsInfo;
+import com.atlassian.plugin.Plugin;
 import com.atlassian.plugin.PluginAccessor;
 import com.atlassian.plugin.spring.scanner.annotation.imports.JiraImport;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
@@ -19,6 +24,8 @@ import javax.ws.rs.core.MediaType;
 @Named
 @Path("/info")
 public class ScioSearchInfo {
+  private static final Logger.Log logger = Logger.getInstance(ScioSearchInfo.class);
+
   @JiraImport
   private final UserManager userManager;
   // Ref: https://docs.atlassian.com/software/jira/docs/api/7.6.1/com/atlassian/jira/config/properties/ApplicationProperties.html
@@ -27,13 +34,20 @@ public class ScioSearchInfo {
   // Ref: https://docs.atlassian.com/software/jira/docs/api/7.6.1/com/atlassian/jira/util/BuildUtilsInfo.html
   @JiraImport
   private final BuildUtilsInfo buildUtilsInfo;
+  @JiraImport
+  private final PluginSettingsFactory pluginSettingsFactory;
+  @JiraImport
+  private final PluginAccessor pluginAccessor;
 
   @Inject
   public ScioSearchInfo(UserManager userManager, ApplicationProperties applicationProperties,
-      BuildUtilsInfo buildUtilsInfo) {
+      BuildUtilsInfo buildUtilsInfo, PluginSettingsFactory pluginSettingsFactory,
+      PluginAccessor pluginAccessor) {
     this.userManager = userManager;
     this.applicationProperties = applicationProperties;
     this.buildUtilsInfo = buildUtilsInfo;
+    this.pluginSettingsFactory = pluginSettingsFactory;
+    this.pluginAccessor = pluginAccessor;
   }
 
   private UserInfo getUserInfo() {
@@ -54,12 +68,33 @@ public class ScioSearchInfo {
     return instanceInfo;
   }
 
+  private ScioPluginInfo getScioPluginInfo() {
+    ScioPluginInfo scioPluginInfo = new ScioPluginInfo();
+
+    final PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
+    final Plugin plugin = pluginAccessor.getPlugin(Constants.PLUGIN_KEY);
+    if (plugin != null && plugin.getPluginInformation() != null) {
+      scioPluginInfo.version = pluginAccessor
+          .getPlugin(Constants.PLUGIN_KEY)
+          .getPluginInformation()
+          .getVersion();
+    } else {
+      logger.warn(String.format("Plugin version not found for %s", Constants.PLUGIN_KEY));
+      scioPluginInfo.version = null;
+    }
+
+    scioPluginInfo.target = (String) pluginSettings.get(TARGET_CONFIG_KEY);
+
+    return scioPluginInfo;
+  }
+
   @GET
   @Produces({MediaType.APPLICATION_JSON})
   public ScioSearchInfoResponse getInfo() {
     ScioSearchInfoResponse response = new ScioSearchInfoResponse();
     response.userInfo = getUserInfo();
     response.instanceInfo = getInstanceInfo();
+    response.scioPluginInfo = getScioPluginInfo();
     return response;
   }
 }

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfoResponse.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchInfoResponse.java
@@ -7,6 +7,7 @@ import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
 public class ScioSearchInfoResponse {
   public UserInfo userInfo;
   public InstanceInfo instanceInfo;
+  public ScioPluginInfo scioPluginInfo;
 
   @JsonAutoDetect(fieldVisibility = Visibility.ANY)
   public static class UserInfo {
@@ -19,7 +20,13 @@ public class ScioSearchInfoResponse {
 
   @JsonAutoDetect(fieldVisibility = Visibility.ANY)
   public static class InstanceInfo {
-    String version;
-    String baseUrl;
+    public String version;
+    public String baseUrl;
+  }
+
+  @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+  public static class ScioPluginInfo {
+    public String version;
+    public String target;
   }
 }


### PR DESCRIPTION
```
$ curl --user 'samba:test' 'http://127.0.0.1:8080/rest/scio_search/1.0/info' | jq .
{
  "userInfo": {
    "userKey": "JIRAUSER10100",
    "userName": "samba",
    "fullName": "Samba Krishna",
    "email": "samba@domain.net",
    "isAdmin": false
  },
  "instanceInfo": {
    "version": "9.0.0",
    "baseUrl": "http://bharath-test-dont-delete:8080"
  },
  "scioPluginInfo": {
    "version": "1.4.0",
    "target": "https://test-be.glean.com/something/jira/scio_event"
  }
}
```