### PR TITLE
[Jira Server] Allow users with Jira Administrators role to access plugin

### DIFF
--- a/jira/server/scio_search/pom.xml
+++ b/jira/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.askscio.atlassian_plugins.jira</groupId>
     <artifactId>glean_search</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
 
 
     <organization>

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchIssueSecurityMembers.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioSearchIssueSecurityMembers.java
@@ -47,18 +47,11 @@ public class ScioSearchIssueSecurityMembers {
     this.pluginSettingsFactory = pluginSettingsFactory;
   }
 
-  private void validateUserIsAdmin() {
-    final UserProfile profile = userManager.getRemoteUser();
-    if (profile == null || !userManager.isSystemAdmin(profile.getUserKey())) {
-      throw new UnauthorizedException("Unauthorized");
-    }
-  }
-
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   public ScioIssueSecurityMembersResponse getIssueSecuritySchemeMembers(@QueryParam("schemeId") String schemeIdStr) {
     logger.debug(String.format("Received request for getting issue security scheme members: %s", schemeIdStr));
-    validateUserIsAdmin();
+    Utils.validateUserIsAdmin(userManager);
     Long schemeId = Long.parseLong(schemeIdStr);
 
     final IssueSecurityLevelManager issueSecurityLevelManager = ComponentAccessor.getIssueSecurityLevelManager();

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/Utils.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/Utils.java
@@ -6,7 +6,7 @@ import com.atlassian.sal.api.user.UserProfile;
 public class Utils {
   public static boolean isCurrentUserAdmin(UserManager userManager) {
     final UserProfile profile = userManager.getRemoteUser();
-    return profile != null && userManager.isSystemAdmin(profile.getUserKey());
+    return profile != null && userManager.isAdmin(profile.getUserKey());
   }
 
   public static void validateUserIsAdmin(UserManager userManager) {


### PR DESCRIPTION
We were earlier only allowing users with `Jira System Administrators` role to do this.
Tested on on-prem instance by creating a group with `Jira Administrators` role and hitting /info for a user in this group - isAdmin is returned as true.

https://askscio.atlassian.net/browse/EN-89285