### PR TITLE
Add timeouts to webhook requests.

### DIFF
--- a/confluence/server/scio_search/pom.xml
+++ b/confluence/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.askscio.atlassian_plugins.confluence</groupId>
   <artifactId>glean_search</artifactId>
-  <version>1.4.1</version>
+  <version>1.4.2</version>
 
   <organization>
     <name>Glean</name>

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
@@ -36,6 +36,8 @@ public class ScioWebhookTask implements Runnable {
       connection.setRequestMethod("POST");
       connection.setRequestProperty("Content-type", "application/json; charset=utf-8");
       connection.setDoOutput(true);
+      connection.setConnectTimeout(60);
+      connection.setReadTimeout(60);
       final OutputStream output = connection.getOutputStream();
       final String json = String.format("{\"url\":\"%s\",\"user\":\"%s\"}", visitedUrl, user);
       final byte[] bytes = json.getBytes(StandardCharsets.UTF_8);

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioWebhookTask.java
@@ -36,8 +36,8 @@ public class ScioWebhookTask implements Runnable {
       connection.setRequestMethod("POST");
       connection.setRequestProperty("Content-type", "application/json; charset=utf-8");
       connection.setDoOutput(true);
-      connection.setConnectTimeout(60);
-      connection.setReadTimeout(60);
+      connection.setConnectTimeout(60000);
+      connection.setReadTimeout(60000);
       final OutputStream output = connection.getOutputStream();
       final String json = String.format("{\"url\":\"%s\",\"user\":\"%s\"}", visitedUrl, user);
       final byte[] bytes = json.getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
I believe these are defaulting to 0, which means no timeout. That means one bad request will hang and block the queue forever.