### PR TITLE
Add timeouts to Jira webhooks.

### DIFF
--- a/jira/server/scio_search/pom.xml
+++ b/jira/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.askscio.atlassian_plugins.jira</groupId>
     <artifactId>glean_search</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
 
 
     <organization>

--- a/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioWebhookTask.java
+++ b/jira/server/scio_search/src/main/java/ScioSearchConfigRestPlugin/impl/ScioWebhookTask.java
@@ -28,6 +28,8 @@ public class ScioWebhookTask implements Runnable {
       connection.setRequestMethod("POST");
       connection.setRequestProperty("Content-type", "application/json; charset=utf-8");
       connection.setDoOutput(true);
+      connection.setConnectTimeout(60000);
+      connection.setReadTimeout(60000);
       final OutputStream output = connection.getOutputStream();
       final String json = String.format("{\"url\":\"%s\",\"user\":\"%s\",\"webhookEvent\":\"VIEW\"}", visitedUrl, user);
       final byte[] bytes = json.getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
Same as we did for Confluence.