### PR TITLE
Replace underscore with dash in configure url

### DIFF
--- a/confluence/server/scio_search/pom.xml
+++ b/confluence/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.askscio.atlassian_plugins.confluence</groupId>
   <artifactId>glean_search</artifactId>
-  <version>1.4.3</version>
+  <version>1.4.4</version>
 
   <organization>
     <name>Glean</name>

--- a/confluence/server/scio_search/src/main/resources/atlassian-plugin.xml
+++ b/confluence/server/scio_search/src/main/resources/atlassian-plugin.xml
@@ -7,7 +7,7 @@
     <param name="plugin-type">both</param>
     <param name="plugin-icon">images/pluginIcon.png</param>
     <param name="plugin-logo">images/pluginLogo.png</param>
-    <param name="configure.url">/admin/plugins/scio_search/scio-search-configure.action</param>
+    <param name="configure.url">/admin/plugins/scio-search/scio-search-configure.action</param>
     <vendor name="${project.organization.name}" url="${project.organization.url}"/>
     <version>${project.version}</version>
     <bundle-instructions>
@@ -42,7 +42,7 @@
 
   <xwork key="scio-search-config-action" name="Scio Search Config Action">
     <package extends="default" name="Scio Search Config Action Package"
-      namespace="/admin/plugins/scio_search">
+      namespace="/admin/plugins/scio-search">
       <action class="com.askscio.atlassian_plugins.confluence.impl.ScioSearchConfigAction"
         method="doDefault" name="scio-search-configure">
         <interceptor-ref name="defaultStack"/>

--- a/confluence/server/scio_search/src/main/resources/vm/configure.vm
+++ b/confluence/server/scio_search/src/main/resources/vm/configure.vm
@@ -5,7 +5,7 @@
     <title>Configure Scio Search Plugin</title>
 </head>
 <body>
-    <form class="aui" name="scio-search-configure-form" method="POST" action="${req.contextPath}/admin/plugins/scio_search/scio-search-do-configure.action">
+    <form class="aui" name="scio-search-configure-form" method="POST" action="${req.contextPath}/admin/plugins/scio-search/scio-search-do-configure.action">
         #form_xsrfToken()
         <h2>Target URL</h2>
 


### PR DESCRIPTION
The old url is not working for newer Confluence version due to some struts failure:
```
There is no Action mapped for namespace [/] and action name [scio-search-configure] associated with context path [/confluence].
```