### PR TITLE
[Confluence Plugin] Add endpoint to get group members.

### DIFF
--- a/confluence/server/scio_search/pom.xml
+++ b/confluence/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.askscio.atlassian_plugins.confluence</groupId>
   <artifactId>glean_search</artifactId>
-  <version>1.4.5</version>
+  <version>1.5.0</version>
 
   <organization>
     <name>Glean</name>

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchGroupMembersFetch.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchGroupMembersFetch.java
@@ -1,0 +1,68 @@
+package com.askscio.atlassian_plugins.confluence.impl;
+
+import static com.askscio.atlassian_plugins.confluence.impl.MyPluginComponentImpl.SERVICE_ACCOUNT_USERNAME_CONFIG_KEY;
+
+import com.atlassian.confluence.user.UserAccessor;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ConfluenceImport;
+import com.atlassian.sal.api.pluginsettings.PluginSettings;
+import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.sal.api.user.UserProfile;
+import com.atlassian.user.Group;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+@Named
+@Path("/group_members")
+public class ScioSearchGroupMembersFetch {
+  @ConfluenceImport private final UserAccessor userAccessor;
+  @ConfluenceImport private final UserManager userManager;
+  @ConfluenceImport private final PluginSettingsFactory pluginSettingsFactory;
+
+  @Inject
+  public ScioSearchGroupMembersFetch(
+      UserAccessor userAccessor,
+      UserManager userManager,
+      PluginSettingsFactory pluginSettingsFactory) {
+    this.userAccessor = userAccessor;
+    this.userManager = userManager;
+    this.pluginSettingsFactory = pluginSettingsFactory;
+  }
+
+  private String getServiceAccountUsername() {
+    PluginSettings pluginSettings = pluginSettingsFactory.createGlobalSettings();
+    return (String) pluginSettings.get(SERVICE_ACCOUNT_USERNAME_CONFIG_KEY);
+  }
+
+  private void validateUserIsServiceAccount() {
+    final UserProfile curentUser = userManager.getRemoteUser();
+    final String serviceAccountUserName = getServiceAccountUsername();
+    if (curentUser == null
+        || serviceAccountUserName == null
+        || serviceAccountUserName.isEmpty()
+        || !serviceAccountUserName.equals(curentUser.getUsername())) {
+      throw new UnauthorizedException("Unauthorized");
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public ScioSearchGroupMembersResponse getGroupMembers(@QueryParam("groupName") String groupName) {
+    validateUserIsServiceAccount();
+    Group group = userAccessor.getGroup(groupName);
+    if (group == null) {
+      throw new NotFoundException("Group not found");
+    }
+    List<String> groupMembers = userAccessor.getMemberNamesAsList(group);
+
+    ScioSearchGroupMembersResponse response = new ScioSearchGroupMembersResponse();
+    response.usernames = groupMembers;
+    return response;
+  }
+}

--- a/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchGroupMembersResponse.java
+++ b/confluence/server/scio_search/src/main/java/com/askscio/atlassian_plugins/confluence/impl/ScioSearchGroupMembersResponse.java
@@ -1,0 +1,12 @@
+package com.askscio.atlassian_plugins.confluence.impl;
+
+import java.util.List;
+import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+public class ScioSearchGroupMembersResponse {
+  @JsonProperty("Usernames")
+  public List<String> usernames; // list of user names of the memebers
+}


### PR DESCRIPTION
This change introduces a new endpoint in plugin fetch names of group members. Since we cannot support pagination due to limitation of the confluence library modules, to keep the plugin execution as lightweight as possible we are just returning the names of the users. Remaining details will be fetched in crawler.

Confluence Library function: https://docs.atlassian.com/ConfluenceServer/javadoc/8.5.18/com/atlassian/confluence/user/UserAccessor.html#getMemberNamesAsList(com.atlassian.user.Group)