### PR TITLE
[Confluence Plugin] Remove deprecated library function GeneralUtil.htmlEncode.

### DIFF
--- a/confluence/server/scio_search/pom.xml
+++ b/confluence/server/scio_search/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.askscio.atlassian_plugins.confluence</groupId>
   <artifactId>glean_search</artifactId>
-  <version>1.5.3</version>
+  <version>1.6.0</version>
 
   <organization>
     <name>Glean</name>

--- a/confluence/server/scio_search/src/main/resources/vm/configure.vm
+++ b/confluence/server/scio_search/src/main/resources/vm/configure.vm
@@ -9,13 +9,13 @@
         #form_xsrfToken()
         <h2>Target URL</h2>
 
-        <input type="text" name="target" id="target" value="$generalUtil.htmlEncode( $target )" class="text">
+        <input type="text" name="target" id="target" value="${target}" class="text">
 
         <div class="description">Configure target url for Scio Search plugin for sending the webhook events.</div>
 
         <h2>Service Account Username</h2>
 
-        <input type="text" name="username" id="username" value="$generalUtil.htmlEncode( $username )" class="text">
+        <input type="text" name="username" id="username" value="${username}" class="text">
 
         <div class="description">Configure Glean Crawler Service Account Username.</div>
 


### PR DESCRIPTION
The library function GeneralUtil.htmlEncode is being deprecated. The recommended function is available only in confluence 9+. I think we can remove this function.
<img width="2632" height="116" alt="image" src="https://github.com/user-attachments/assets/d4784201-270e-404b-acc5-fa1cf2597044" />

https://docs.atlassian.com/ConfluenceServer/javadoc/7.7.4/com/atlassian/confluence/util/GeneralUtil.html